### PR TITLE
Remove tests and don't run examples using the api

### DIFF
--- a/R/locate.R
+++ b/R/locate.R
@@ -11,7 +11,9 @@
 #' @return A string or a tibble.
 #' @export
 #' @examples
+#' \dontrun{
 #' locate_ip("132.203.167.188")
+#' }
 locate_ip <-
   function(ip,
            fields = c("status,message,country,city"),

--- a/man/locate_ip.Rd
+++ b/man/locate_ip.Rd
@@ -25,5 +25,7 @@ A string or a tibble.
 For API documentation and terms of service, see \href{https://ip-api.com/}{ip-api.com}.
 }
 \examples{
+\dontrun{
 locate_ip("132.203.167.188")
+}
 }

--- a/tests/testthat/test-locate.R
+++ b/tests/testthat/test-locate.R
@@ -25,27 +25,6 @@ test_that("tidy location works", {
   )
 })
 
-test_that("locate ip works", {
-  output <- tibble::tibble(
-    status = "success",
-    message = NA,
-    country = "Canada",
-    city = "Québec"
-  )
-
-  expect_equal(
-    locate_ip("132.203.167.188", fields = "status,message,country,city", tidy = TRUE),
-    output
-  )
-
-  output <- "success,Canada,Québec\n"
-
-  expect_equal(
-    locate_ip("132.203.167.188", fields = "status,message,country,city", tidy = FALSE),
-    output
-  )
-})
-
 test_that("create request works", {
   req <- create_req()
   expect_equal(req[["url"]],


### PR DESCRIPTION
The API might not always be available, so this would avoid tests from failing because of it.

It seems to be why the latest checks [failed](https://github.com/clessn/locateip/actions/runs/4840384026/jobs/8625991539).