### PR TITLE
Pause execution if request limit reached

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: locateip
 Title: Locate IP Addresses with 'ip-api'
-Version: 0.1.3
+Version: 0.1.3.9000
 Authors@R: 
     person("Judith", "Bourque", , "judith.bourque.2@ulaval.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0000-3653-1530"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# locateip (development version)
+
 # locateip 0.1.3
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/locate.R
+++ b/R/locate.R
@@ -97,8 +97,8 @@ get_location <-
       httr2::req_perform()
 
     # If there's no remaining requests, pause execution
-    if (httr2::resp_header(resp, "X-Rl") == 0) {
-      Sys.sleep(httr2::resp_header(resp, "X-Ttl"))
+    if (as.numeric(httr2::resp_header(resp, "X-Rl")) == 0) {
+      Sys.sleep(as.numeric(httr2::resp_header(resp, "X-Ttl")) + 5)
     }
 
     return(resp)

--- a/R/locate.R
+++ b/R/locate.R
@@ -96,6 +96,7 @@ get_location <-
     resp <- create_req(ip = ip, fields = fields, lang = lang, header = header, ..., format = format) |>
       httr2::req_perform()
 
+    # If there's no remaining requests, pause execution
     if (httr2::resp_header(resp, "X-Rl") == 0) {
       Sys.sleep(httr2::resp_header(resp, "X-Ttl"))
     }

--- a/R/locate.R
+++ b/R/locate.R
@@ -96,6 +96,10 @@ get_location <-
     resp <- create_req(ip = ip, fields = fields, lang = lang, header = header, ..., format = format) |>
       httr2::req_perform()
 
+    if (httr2::resp_header(resp, "X-Rl") == 0) {
+      Sys.sleep(httr2::resp_header(resp, "X-Ttl"))
+    }
+
     return(resp)
   }
 

--- a/R/locate.R
+++ b/R/locate.R
@@ -98,7 +98,7 @@ get_location <-
 
     # If there's no remaining requests, pause execution
     if (as.numeric(httr2::resp_header(resp, "X-Rl")) == 0) {
-      Sys.sleep(as.numeric(httr2::resp_header(resp, "X-Ttl")) + 5)
+      Sys.sleep(as.numeric(httr2::resp_header(resp, "X-Ttl")))
     }
 
     return(resp)


### PR DESCRIPTION
Check in the response if the request limit was reached and pause for the amount of time provided in the response.

This will help respect the API policy: 

"The returned HTTP header X-Rl contains the number of requests remaining in the current rate limit window. X-Ttl contains the seconds until the limit is reset.

Your implementation should always check the value of the X-Rl header, and if its is 0 you must not send any more requests for the duration of X-Ttl in seconds." ([source](https://ip-api.com/docs/api:csv))

Closes #122 